### PR TITLE
Fix Ticket #11123: Accumulators: adjust type fusion::nil to fusion::nil_

### DIFF
--- a/include/boost/accumulators/framework/depends_on.hpp
+++ b/include/boost/accumulators/framework/depends_on.hpp
@@ -223,13 +223,13 @@ namespace boost { namespace accumulators
         template<typename First, typename Last>
         struct build_acc_list<First, Last, true>
         {
-            typedef fusion::nil type;
+            typedef fusion::nil_ type;
 
             template<typename Args>
-            static fusion::nil
+            static fusion::nil_
             call(Args const &, First const&, Last const&)
             {
-                return fusion::nil();
+                return fusion::nil_();
             }
         };
 


### PR DESCRIPTION
Fusion renamed the actual type to 'nil_' back in SVN r81628 in order to make it friendlier to ObjC++ (where "nil" is a keyword, sadly). This patch adjusts accumulators to match.