### PR TITLE
Fix example in doc

### DIFF
--- a/doc/accumulators.qbk
+++ b/doc/accumulators.qbk
@@ -101,7 +101,7 @@ calculates the mean and 2nd moment of a sequence of doubles.
 
         // Display the results ...
         std::cout << "Mean:   " << mean(acc) << std::endl;
-        std::cout << "Moment: " << accumulators::moment<2>(acc) << std::endl;
+        std::cout << "Moment: " << moment<2>(acc) << std::endl;
 
         return 0;
     }


### PR DESCRIPTION
Make the example compilable 

See https://stackoverflow.com/q/37731872. It's either this or add a `using namespace boost;`