### PR TITLE
replace deprecated binders and adapters by more modern equivalents

### DIFF
--- a/include/boost/accumulators/numeric/functional.hpp
+++ b/include/boost/accumulators/numeric/functional.hpp
@@ -99,11 +99,9 @@ namespace boost { namespace numeric
         };                                                                                      \
         template<typename Arg, typename EnableIf>                                               \
         struct Name ## _base                                                                    \
-          : std::unary_function<                                                                \
-                typename remove_const<Arg>::type                                                \
-              , typename result_of_ ## Name<Arg>::type                                          \
-            >                                                                                   \
         {                                                                                       \
+            typedef typename remove_const<Arg>::type argument_type;                             \
+            typedef typename result_of_ ## Name<Arg>::type result_type;                         \
             typename result_of_ ## Name<Arg>::type operator ()(Arg &arg) const                  \
             {                                                                                   \
                 return Op arg;                                                                  \
@@ -138,12 +136,10 @@ namespace boost { namespace numeric
         };                                                                                      \
         template<typename Left, typename Right, typename EnableIf>                              \
         struct Name ## _base                                                                    \
-          : std::binary_function<                                                               \
-                typename remove_const<Left>::type                                               \
-              , typename remove_const<Right>::type                                              \
-              , typename result_of_ ## Name<Left, Right>::type                                  \
-            >                                                                                   \
         {                                                                                       \
+            typedef typename remove_const<Left>::type first_argument_type;                      \
+            typedef typename remove_const<Right>::type second_argument_type;                    \
+            typedef typename result_of_ ## Name<Left, Right>::type result_type;                 \
             typename result_of_ ## Name<Left, Right>::type                                      \
             operator ()(Left &left, Right &right) const                                         \
             {                                                                                   \
@@ -220,8 +216,11 @@ namespace boost { namespace numeric
     {
         template<typename Left, typename Right, typename EnableIf>
         struct min_assign_base
-          : std::binary_function<Left, Right, void>
         {
+            typedef Left first_argument_type;
+            typedef Right second_argument_type;
+            typedef void result_type;
+
             void operator ()(Left &left, Right &right) const
             {
                 if(numeric::less(right, left))
@@ -233,8 +232,11 @@ namespace boost { namespace numeric
 
         template<typename Left, typename Right, typename EnableIf>
         struct max_assign_base
-          : std::binary_function<Left, Right, void>
         {
+            typedef Left first_argument_type;
+            typedef Right second_argument_type;
+            typedef void result_type;
+
             void operator ()(Left &left, Right &right) const
             {
                 if(numeric::greater(right, left))
@@ -258,8 +260,10 @@ namespace boost { namespace numeric
 
         template<typename To, typename From, typename EnableIf>
         struct promote_base
-          : std::unary_function<From, To>
         {
+            typedef From argument_type;
+            typedef To result_type;
+
             To operator ()(From &from) const
             {
                 return from;
@@ -268,8 +272,10 @@ namespace boost { namespace numeric
 
         template<typename ToFrom>
         struct promote_base<ToFrom, ToFrom, void>
-          : std::unary_function<ToFrom, ToFrom>
         {
+            typedef ToFrom argument_type;
+            typedef ToFrom result_type;
+
             ToFrom &operator ()(ToFrom &tofrom)
             {
                 return tofrom;
@@ -278,9 +284,11 @@ namespace boost { namespace numeric
 
         template<typename Arg, typename EnableIf>
         struct as_min_base
-          : std::unary_function<Arg, typename remove_const<Arg>::type>
         {
             BOOST_STATIC_ASSERT(std::numeric_limits<typename remove_const<Arg>::type>::is_specialized);
+
+            typedef Arg argument_type;
+            typedef typename remove_const<Arg>::type result_type;
 
             typename remove_const<Arg>::type operator ()(Arg &) const
             {
@@ -290,9 +298,11 @@ namespace boost { namespace numeric
 
         template<typename Arg>
         struct as_min_base<Arg, typename enable_if<is_floating_point<Arg> >::type>
-          : std::unary_function<Arg, typename remove_const<Arg>::type>
         {
             BOOST_STATIC_ASSERT(std::numeric_limits<typename remove_const<Arg>::type>::is_specialized);
+
+            typedef Arg argument_type;
+            typedef typename remove_const<Arg>::type result_type;
 
             typename remove_const<Arg>::type operator ()(Arg &) const
             {
@@ -302,9 +312,11 @@ namespace boost { namespace numeric
 
         template<typename Arg, typename EnableIf>
         struct as_max_base
-          : std::unary_function<Arg, typename remove_const<Arg>::type>
         {
             BOOST_STATIC_ASSERT(std::numeric_limits<typename remove_const<Arg>::type>::is_specialized);
+
+            typedef Arg argument_type;
+            typedef typename remove_const<Arg>::type result_type;
 
             typename remove_const<Arg>::type operator ()(Arg &) const
             {
@@ -314,8 +326,10 @@ namespace boost { namespace numeric
 
         template<typename Arg, typename EnableIf>
         struct as_zero_base
-          : std::unary_function<Arg, typename remove_const<Arg>::type>
         {
+            typedef Arg argument_type;
+            typedef typename remove_const<Arg>::type result_type;
+
             typename remove_const<Arg>::type operator ()(Arg &) const
             {
                 return numeric::zero<typename remove_const<Arg>::type>::value;
@@ -324,8 +338,10 @@ namespace boost { namespace numeric
 
         template<typename Arg, typename EnableIf>
         struct as_one_base
-          : std::unary_function<Arg, typename remove_const<Arg>::type>
         {
+            typedef Arg argument_type;
+            typedef typename remove_const<Arg>::type result_type;
+
             typename remove_const<Arg>::type operator ()(Arg &) const
             {
                 return numeric::one<typename remove_const<Arg>::type>::value;

--- a/include/boost/accumulators/numeric/functional/valarray.hpp
+++ b/include/boost/accumulators/numeric/functional/valarray.hpp
@@ -118,17 +118,9 @@ namespace boost { namespace numeric
     #define BOOST_NUMERIC_FUNCTIONAL_DEFINE_VALARRAY_BIN_OP(Name, Op)                   \
         template<typename Left, typename Right>                                         \
         struct Name<Left, Right, std_valarray_tag, std_valarray_tag>                    \
-          : std::binary_function<                                                       \
-                Left                                                                    \
-              , Right                                                                   \
-              , std::valarray<                                                          \
-                    typename Name<                                                      \
-                        typename Left::value_type                                       \
-                      , typename Right::value_type                                      \
-                    >::result_type                                                      \
-                >                                                                       \
-            >                                                                           \
         {                                                                               \
+            typedef Left first_argument_type;                                           \
+            typedef Right second_argument_type;                                         \
             typedef typename Left::value_type left_value_type;                          \
             typedef typename Right::value_type right_value_type;                        \
             typedef                                                                     \
@@ -145,14 +137,9 @@ namespace boost { namespace numeric
         };                                                                              \
         template<typename Left, typename Right>                                         \
         struct Name<Left, Right, std_valarray_tag, void>                                \
-          : std::binary_function<                                                       \
-                Left                                                                    \
-              , Right                                                                   \
-              , std::valarray<                                                          \
-                    typename Name<typename Left::value_type, Right>::result_type        \
-                >                                                                       \
-            >                                                                           \
         {                                                                               \
+            typedef Left first_argument_type;                                           \
+            typedef Right second_argument_type;                                         \
             typedef typename Left::value_type left_value_type;                          \
             typedef                                                                     \
                 std::valarray<                                                          \
@@ -167,14 +154,9 @@ namespace boost { namespace numeric
         };                                                                              \
         template<typename Left, typename Right>                                         \
         struct Name<Left, Right, void, std_valarray_tag>                                \
-          : std::binary_function<                                                       \
-                Left                                                                    \
-              , Right                                                                   \
-              , std::valarray<                                                          \
-                    typename Name<Left, typename Right::value_type>::result_type        \
-                >                                                                       \
-            >                                                                           \
         {                                                                               \
+            typedef Left first_argument_type;                                           \
+            typedef Right second_argument_type;                                         \
             typedef typename Right::value_type right_value_type;                        \
             typedef                                                                     \
                 std::valarray<                                                          \
@@ -200,8 +182,11 @@ namespace boost { namespace numeric
         // element-wise min of std::valarray
         template<typename Left, typename Right>
         struct min_assign<Left, Right, std_valarray_tag, std_valarray_tag>
-          : std::binary_function<Left, Right, void>
         {
+            typedef Left first_argument_type;
+            typedef Right second_argument_type;
+            typedef void result_type;
+
             void operator ()(Left &left, Right &right) const
             {
                 BOOST_ASSERT(left.size() == right.size());
@@ -219,8 +204,11 @@ namespace boost { namespace numeric
         // element-wise max of std::valarray
         template<typename Left, typename Right>
         struct max_assign<Left, Right, std_valarray_tag, std_valarray_tag>
-          : std::binary_function<Left, Right, void>
         {
+            typedef Left first_argument_type;
+            typedef Right second_argument_type;
+            typedef void result_type;
+
             void operator ()(Left &left, Right &right) const
             {
                 BOOST_ASSERT(left.size() == right.size());
@@ -247,8 +235,10 @@ namespace boost { namespace numeric
         // promote
         template<typename To, typename From>
         struct promote<To, From, std_valarray_tag, std_valarray_tag>
-          : std::unary_function<From, To>
         {
+            typedef From argument_type;
+            typedef To result_type;
+
             To operator ()(From &arr) const
             {
                 typename remove_const<To>::type res(arr.size());
@@ -262,8 +252,10 @@ namespace boost { namespace numeric
 
         template<typename ToFrom>
         struct promote<ToFrom, ToFrom, std_valarray_tag, std_valarray_tag>
-          : std::unary_function<ToFrom, ToFrom>
         {
+            typedef ToFrom argument_type;
+            typedef ToFrom result_type;
+
             ToFrom &operator ()(ToFrom &tofrom) const
             {
                 return tofrom;
@@ -275,8 +267,10 @@ namespace boost { namespace numeric
         //   if(numeric::promote<bool>(a == b))
         template<typename From>
         struct promote<bool, From, void, std_valarray_tag>
-          : std::unary_function<From, bool>
         {
+            typedef From argument_type;
+            typedef bool result_type;
+
             bool operator ()(From &arr) const
             {
                 BOOST_MPL_ASSERT((is_same<bool, typename From::value_type>));
@@ -300,8 +294,10 @@ namespace boost { namespace numeric
         // functional::as_min
         template<typename T>
         struct as_min<T, std_valarray_tag>
-            : std::unary_function<T, typename remove_const<T>::type>
         {
+            typedef T argument_type;
+            typedef typename remove_const<T>::type result_type;
+
             typename remove_const<T>::type operator ()(T &arr) const
             {
                 return 0 == arr.size()
@@ -314,8 +310,10 @@ namespace boost { namespace numeric
         // functional::as_max
         template<typename T>
         struct as_max<T, std_valarray_tag>
-          : std::unary_function<T, typename remove_const<T>::type>
         {
+            typedef T argument_type;
+            typedef typename remove_const<T>::type result_type;
+
             typename remove_const<T>::type operator ()(T &arr) const
             {
                 return 0 == arr.size()
@@ -328,8 +326,10 @@ namespace boost { namespace numeric
         // functional::as_zero
         template<typename T>
         struct as_zero<T, std_valarray_tag>
-          : std::unary_function<T, typename remove_const<T>::type>
         {
+            typedef T argument_type;
+            typedef typename remove_const<T>::type result_type;
+
             typename remove_const<T>::type operator ()(T &arr) const
             {
                 return 0 == arr.size()
@@ -342,8 +342,10 @@ namespace boost { namespace numeric
         // functional::as_one
         template<typename T>
         struct as_one<T, std_valarray_tag>
-          : std::unary_function<T, typename remove_const<T>::type>
         {
+            typedef T argument_type;
+            typedef typename remove_const<T>::type result_type;
+
             typename remove_const<T>::type operator ()(T &arr) const
             {
                 return 0 == arr.size()

--- a/include/boost/accumulators/numeric/functional/vector.hpp
+++ b/include/boost/accumulators/numeric/functional/vector.hpp
@@ -195,8 +195,11 @@ namespace boost { namespace numeric
         // element-wise min of std::vector
         template<typename Left, typename Right>
         struct min_assign<Left, Right, std_vector_tag, std_vector_tag>
-          : std::binary_function<Left, Right, void>
         {
+            typedef Left first_argument_type;
+            typedef Right second_argument_type;
+            typedef void result_type;
+
             void operator ()(Left &left, Right &right) const
             {
                 BOOST_ASSERT(left.size() == right.size());
@@ -214,8 +217,11 @@ namespace boost { namespace numeric
         // element-wise max of std::vector
         template<typename Left, typename Right>
         struct max_assign<Left, Right, std_vector_tag, std_vector_tag>
-          : std::binary_function<Left, Right, void>
         {
+            typedef Left first_argument_type;
+            typedef Right second_argument_type;
+            typedef void result_type;
+
             void operator ()(Left &left, Right &right) const
             {
                 BOOST_ASSERT(left.size() == right.size());
@@ -242,8 +248,10 @@ namespace boost { namespace numeric
         // promote
         template<typename To, typename From>
         struct promote<To, From, std_vector_tag, std_vector_tag>
-          : std::unary_function<From, To>
         {
+            typedef From argument_type;
+            typedef To result_type;
+
             To operator ()(From &arr) const
             {
                 typename remove_const<To>::type res(arr.size());
@@ -257,8 +265,10 @@ namespace boost { namespace numeric
 
         template<typename ToFrom>
         struct promote<ToFrom, ToFrom, std_vector_tag, std_vector_tag>
-          : std::unary_function<ToFrom, ToFrom>
         {
+            typedef ToFrom argument_type;
+            typedef ToFrom result_type;
+
             ToFrom &operator ()(ToFrom &tofrom) const
             {
                 return tofrom;
@@ -269,8 +279,10 @@ namespace boost { namespace numeric
         // functional::as_min
         template<typename T>
         struct as_min<T, std_vector_tag>
-          : std::unary_function<T, typename remove_const<T>::type>
         {
+            typedef T argument_type;
+            typedef typename remove_const<T>::type result_type;
+
             typename remove_const<T>::type operator ()(T &arr) const
             {
                 return 0 == arr.size()
@@ -283,8 +295,10 @@ namespace boost { namespace numeric
         // functional::as_max
         template<typename T>
         struct as_max<T, std_vector_tag>
-          : std::unary_function<T, typename remove_const<T>::type>
         {
+            typedef T argument_type;
+            typedef typename remove_const<T>::type result_type;
+
             typename remove_const<T>::type operator ()(T &arr) const
             {
                 return 0 == arr.size()
@@ -297,8 +311,10 @@ namespace boost { namespace numeric
         // functional::as_zero
         template<typename T>
         struct as_zero<T, std_vector_tag>
-          : std::unary_function<T, typename remove_const<T>::type>
         {
+            typedef T argument_type;
+            typedef typename remove_const<T>::type result_type;
+
             typename remove_const<T>::type operator ()(T &arr) const
             {
                 return 0 == arr.size()
@@ -311,8 +327,10 @@ namespace boost { namespace numeric
         // functional::as_one
         template<typename T>
         struct as_one<T, std_vector_tag>
-          : std::unary_function<T, typename remove_const<T>::type>
         {
+            typedef T argument_type;
+            typedef typename remove_const<T>::type result_type;
+
             typename remove_const<T>::type operator ()(T &arr) const
             {
                 return 0 == arr.size()

--- a/include/boost/accumulators/statistics/covariance.hpp
+++ b/include/boost/accumulators/statistics/covariance.hpp
@@ -50,17 +50,9 @@ namespace boost { namespace numeric
 
         template<typename Left, typename Right>
         struct outer_product<Left, Right, std_vector_tag, std_vector_tag>
-          : std::binary_function<
-                Left
-              , Right
-              , ublas::matrix<
-                    typename functional::multiplies<
-                        typename Left::value_type
-                      , typename Right::value_type
-                    >::result_type
-                >
-            >
         {
+            typedef Left first_argument_type;
+            typedef Right second_argument_type;
             typedef
                 ublas::matrix<
                     typename functional::multiplies<

--- a/include/boost/accumulators/statistics/tail.hpp
+++ b/include/boost/accumulators/statistics/tail.hpp
@@ -248,8 +248,11 @@ namespace impl
         ///////////////////////////////////////////////////////////////////////////////
         //
         struct indirect_cmp
-          : std::binary_function<std::size_t, std::size_t, bool>
         {
+            typedef std::size_t first_argument_type;
+            typedef std::size_t second_argument_type;
+            typedef bool result_type;
+
             indirect_cmp(std::vector<Sample> const &s)
               : samples(s)
             {

--- a/include/boost/accumulators/statistics/tail_variate_means.hpp
+++ b/include/boost/accumulators/statistics/tail_variate_means.hpp
@@ -118,7 +118,11 @@ namespace impl
                     this->tail_means_.begin()
                   , this->tail_means_.end()
                   , this->tail_means_.begin()
+#ifdef BOOST_NO_CXX98_BINDERS
+                  , std::bind(std::divides<float_type>(), std::placeholders::_1, factor)
+#else
                   , std::bind2nd(std::divides<float_type>(), factor)
+#endif
                 );
             }
             else

--- a/include/boost/accumulators/statistics/times2_iterator.hpp
+++ b/include/boost/accumulators/statistics/times2_iterator.hpp
@@ -23,7 +23,11 @@ namespace boost { namespace accumulators
 namespace detail
 {
     typedef transform_iterator<
+#ifdef BOOST_NO_CXX98_BINDERS
+        decltype(std::bind(std::multiplies<std::size_t>(), 2, std::placeholders::_1))
+#else
         std::binder1st<std::multiplies<std::size_t> >
+#endif
       , counting_iterator<std::size_t>
     > times2_iterator;
 
@@ -31,7 +35,11 @@ namespace detail
     {
         return make_transform_iterator(
             make_counting_iterator(i)
+#ifdef BOOST_NO_CXX98_BINDERS
+          , std::bind(std::multiplies<std::size_t>(), 2, std::placeholders::_1)
+#else
           , std::bind1st(std::multiplies<std::size_t>(), 2)
+#endif
         );
     }
 

--- a/include/boost/accumulators/statistics/weighted_tail_variate_means.hpp
+++ b/include/boost/accumulators/statistics/weighted_tail_variate_means.hpp
@@ -169,7 +169,11 @@ namespace impl
                 this->tail_means_.begin()
               , this->tail_means_.end()
               , this->tail_means_.begin()
+#ifdef BOOST_NO_CXX98_BINDERS
+              , std::bind(numeric::functional::divides<typename array_type::value_type const, float_type const>(), std::placeholders::_1, factor)
+#else
               , std::bind2nd(numeric::functional::divides<typename array_type::value_type const, float_type const>(), factor)
+#endif
             );
 
             return make_iterator_range(this->tail_means_);


### PR DESCRIPTION
**replace deprecated binders and adapters by more modern equivalents**

Required with latest msvc versions and compiler option /std:c++latest