### PR TITLE
Allow accumulator persistency

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -246,3 +246,12 @@ boostbook standalone
         <format>pdf:<xsl:param>boost.url.prefix=http://www.boost.org/doc/libs/release/doc/html
     ;
 
+###############################################################################
+alias boostdoc
+    : accumulators
+    :
+    : <dependency>accdoc <dependency>statsdoc <dependency>opdoc
+    : ;
+explicit boostdoc ;
+alias boostrelease ;
+explicit boostrelease ;

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -8,4 +8,6 @@ exe example
     :
         <include>../../..
         <include>$(BOOST_ROOT)
+        <library>/boost/serialization
+        <cxxflags>"-Wno-deprecated-declarations"
     ;

--- a/include/boost/accumulators/framework/accumulator_set.hpp
+++ b/include/boost/accumulators/framework/accumulator_set.hpp
@@ -86,6 +86,25 @@ namespace detail
     {
     };
 
+    // function object that serialize an accumulator
+    template<typename Archive>
+    struct serialize_accumulator
+    {
+        serialize_accumulator(Archive & _ar, const unsigned int _file_version) :
+            ar(_ar), file_version(_file_version)
+        {}
+
+        template<typename Accumulator>
+        void operator ()(Accumulator &accumulator)
+        {
+            accumulator.serialize(ar, file_version);
+        }
+
+    private:
+        Archive& ar;
+        const unsigned int file_version;
+    };
+
 } // namespace detail
 
 #ifdef _MSC_VER
@@ -336,6 +355,14 @@ struct accumulator_set
         this->template visit_if<detail::contains_feature_of_<dependencies> >(
             detail::make_drop_visitor(detail::accumulator_params()(*this))
         );
+    }
+
+    // make the accumulator set serializeable
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int file_version)
+    {
+        detail::serialize_accumulator<Archive> serializer(ar, file_version);
+        fusion::for_each(this->accumulators, serializer);
     }
 
 private:

--- a/include/boost/accumulators/statistics/count.hpp
+++ b/include/boost/accumulators/statistics/count.hpp
@@ -43,6 +43,13 @@ namespace impl
             return this->cnt;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & cnt;
+        }
+
     private:
         std::size_t cnt;
     };

--- a/include/boost/accumulators/statistics/covariance.hpp
+++ b/include/boost/accumulators/statistics/covariance.hpp
@@ -152,6 +152,13 @@ namespace impl
             return this->cov_;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & cov_;
+        }
+
     private:
         result_type cov_;
     };

--- a/include/boost/accumulators/statistics/density.hpp
+++ b/include/boost/accumulators/statistics/density.hpp
@@ -25,6 +25,8 @@
 #include <boost/accumulators/statistics/count.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/min.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/utility.hpp>
 
 namespace boost { namespace accumulators
 {
@@ -182,6 +184,20 @@ namespace impl
             }
             // returns a range of pairs
             return make_iterator_range(this->histogram);
+        }
+
+        // make this accumulator serializeable
+        // TODO split to save/load and check on parameters provided in ctor
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & cache_size;
+            ar & cache;
+            ar & num_bins;
+            ar & samples_in_bin;
+            ar & bin_positions;
+            ar & histogram;
+            ar & is_dirty; 
         }
 
     private:

--- a/include/boost/accumulators/statistics/extended_p_square.hpp
+++ b/include/boost/accumulators/statistics/extended_p_square.hpp
@@ -26,6 +26,7 @@
 #include <boost/accumulators/statistics_fwd.hpp>
 #include <boost/accumulators/statistics/count.hpp>
 #include <boost/accumulators/statistics/times2_iterator.hpp>
+#include <boost/serialization/vector.hpp>
 
 namespace boost { namespace accumulators
 {
@@ -234,6 +235,19 @@ namespace impl
                 make_permutation_iterator(this->heights.begin(), idx_begin)
               , make_permutation_iterator(this->heights.begin(), idx_end)
             );
+        }
+
+    public:
+        // make this accumulator serializeable
+        // TODO: do we need to split to load/save and verify that the parameters did not change?
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & probabilities;
+            ar & heights;
+            ar & actual_positions;
+            ar & desired_positions;
+            ar & positions_increments;
         }
 
     private:

--- a/include/boost/accumulators/statistics/extended_p_square_quantile.hpp
+++ b/include/boost/accumulators/statistics/extended_p_square_quantile.hpp
@@ -185,6 +185,17 @@ namespace impl
             }
 
         }
+
+    public:
+        // make this accumulator serializeable
+        // TODO: do we need to split to load/save and verify that the parameters did not change?
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & probabilities;
+            ar & probability;
+        }
+
     private:
 
         array_type probabilities;

--- a/include/boost/accumulators/statistics/kurtosis.hpp
+++ b/include/boost/accumulators/statistics/kurtosis.hpp
@@ -63,6 +63,10 @@ namespace impl
                         * ( accumulators::moment<2>(args) - mean(args) * mean(args) )
                     ) - 3.;
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 
 } // namespace impl

--- a/include/boost/accumulators/statistics/max.hpp
+++ b/include/boost/accumulators/statistics/max.hpp
@@ -48,6 +48,13 @@ namespace impl
             return this->max_;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & max_;
+        }
+
     private:
         Sample max_;
     };

--- a/include/boost/accumulators/statistics/mean.hpp
+++ b/include/boost/accumulators/statistics/mean.hpp
@@ -41,6 +41,10 @@ namespace impl
             extractor<SumFeature> sum;
             return numeric::fdiv(sum(args), count(args));
         }
+
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 
     template<typename Sample, typename Tag>
@@ -69,6 +73,13 @@ namespace impl
         result_type result(dont_care) const
         {
             return this->mean;
+        }
+
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & mean;
         }
 
     private:

--- a/include/boost/accumulators/statistics/mean.hpp
+++ b/include/boost/accumulators/statistics/mean.hpp
@@ -75,7 +75,6 @@ namespace impl
             return this->mean;
         }
 
-        // make this accumulator serializeable
         template<class Archive>
         void serialize(Archive & ar, const unsigned int file_version)
         { 

--- a/include/boost/accumulators/statistics/median.hpp
+++ b/include/boost/accumulators/statistics/median.hpp
@@ -48,6 +48,10 @@ namespace impl
         {
             return p_square_quantile_for_median(args);
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
     ///////////////////////////////////////////////////////////////////////////////
     // with_density_median_impl
@@ -105,6 +109,16 @@ namespace impl
             return this->median;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & sum;
+            ar & is_dirty;
+            ar & median;
+        }
+
+
     private:
         mutable float_type sum;
         mutable bool is_dirty;
@@ -160,6 +174,15 @@ namespace impl
 
             return this->median;
         }
+        
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & is_dirty;
+            ar & median;
+        }
+
     private:
 
         mutable bool is_dirty;

--- a/include/boost/accumulators/statistics/min.hpp
+++ b/include/boost/accumulators/statistics/min.hpp
@@ -48,6 +48,13 @@ namespace impl
             return this->min_;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & min_;
+        }
+
     private:
         Sample min_;
     };

--- a/include/boost/accumulators/statistics/moment.hpp
+++ b/include/boost/accumulators/statistics/moment.hpp
@@ -75,6 +75,13 @@ namespace impl
             return numeric::fdiv(this->sum, count(args));
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & sum;
+        }
+
     private:
         Sample sum;
     };

--- a/include/boost/accumulators/statistics/p_square_cumul_dist.hpp
+++ b/include/boost/accumulators/statistics/p_square_cumul_dist.hpp
@@ -20,6 +20,8 @@
 #include <boost/accumulators/framework/parameters/sample.hpp>
 #include <boost/accumulators/statistics_fwd.hpp>
 #include <boost/accumulators/statistics/count.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/utility.hpp>
 
 namespace boost { namespace accumulators
 {
@@ -203,6 +205,20 @@ namespace impl
             }
             //return histogram;
             return make_iterator_range(this->histogram);
+        }
+    
+        // make this accumulator serializeable
+        // TODO split to save/load and check on parameters provided in ctor
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & num_cells;
+            ar & heights;
+            ar & actual_positions;
+            ar & desired_positions;
+            ar & positions_increments;
+            ar & histogram;
+            ar & is_dirty; 
         }
 
     private:

--- a/include/boost/accumulators/statistics/p_square_quantile.hpp
+++ b/include/boost/accumulators/statistics/p_square_quantile.hpp
@@ -22,6 +22,7 @@
 #include <boost/accumulators/statistics_fwd.hpp>
 #include <boost/accumulators/statistics/count.hpp>
 #include <boost/accumulators/statistics/parameters/quantile_probability.hpp>
+#include <boost/serialization/boost_array.hpp>
 
 namespace boost { namespace accumulators
 {
@@ -189,6 +190,18 @@ namespace impl
         result_type result(dont_care) const
         {
             return this->heights[2];
+        }
+
+        // make this accumulator serializeable
+        // TODO: do we need to split to load/save and verify that P did not change?
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & p;
+            ar & heights;
+            ar & actual_positions;
+            ar & desired_positions;
+            ar & positions_increments;
         }
 
     private:

--- a/include/boost/accumulators/statistics/peaks_over_threshold.hpp
+++ b/include/boost/accumulators/statistics/peaks_over_threshold.hpp
@@ -181,6 +181,21 @@ namespace impl
             return this->fit_parameters_;
         }
 
+        // make this accumulator serializeable
+        // TODO: do we need to split to load/save and verify that threshold did not change?
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & Nu_;
+            ar & mu_;
+            ar & sigma2_;
+            ar & threshold_;
+            ar & get<0>(fit_parameters_);
+            ar & get<1>(fit_parameters_);
+            ar & get<2>(fit_parameters_);
+            ar & is_dirty_;
+        }
+
     private:
         std::size_t Nu_;                     // number of samples larger than threshold
         mutable float_type mu_;              // mean of Nu_ largest samples
@@ -289,6 +304,20 @@ namespace impl
             }
 
             return this->fit_parameters_;
+        }
+
+        // make this accumulator serializeable
+        // TODO: do we need to split to load/save and verify that threshold did not change?
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & mu_;
+            ar & sigma2_;
+            ar & threshold_probability_;
+            ar & get<0>(fit_parameters_);
+            ar & get<1>(fit_parameters_);
+            ar & get<2>(fit_parameters_);
+            ar & is_dirty_;
         }
 
     private:

--- a/include/boost/accumulators/statistics/pot_quantile.hpp
+++ b/include/boost/accumulators/statistics/pot_quantile.hpp
@@ -80,6 +80,13 @@ namespace impl
                 , -xi_hat
               ) - 1.));
         }
+    
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & sign_;
+        }
 
     private:
         short sign_; // if the fit parameters from the mirrored left tail extreme values are used, mirror back the result

--- a/include/boost/accumulators/statistics/pot_tail_mean.hpp
+++ b/include/boost/accumulators/statistics/pot_tail_mean.hpp
@@ -90,6 +90,14 @@ namespace impl
                 is_same<LeftRight, left>::value ? args[quantile_probability] : 1. - args[quantile_probability]
               , -xi_hat);
         }
+    
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & sign_;
+        }
+
     private:
         short sign_; // if the fit parameters from the mirrored left tail extreme values are used, mirror back the result
     };

--- a/include/boost/accumulators/statistics/rolling_count.hpp
+++ b/include/boost/accumulators/statistics/rolling_count.hpp
@@ -40,6 +40,10 @@ namespace impl
         {
             return static_cast<std::size_t>(rolling_window_plus1(args).size()) - is_rolling_window_plus1_full(args);
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 
 } // namespace impl

--- a/include/boost/accumulators/statistics/rolling_mean.hpp
+++ b/include/boost/accumulators/statistics/rolling_mean.hpp
@@ -43,6 +43,10 @@ namespace boost { namespace accumulators
          {
             return numeric::fdiv(rolling_sum(args), rolling_count(args));
          }
+        
+         // serialization is done by accumulators it depends on
+         template<class Archive>
+         void serialize(Archive & ar, const unsigned int file_version) {}
       };
 
       ///////////////////////////////////////////////////////////////////////////////
@@ -80,6 +84,13 @@ namespace boost { namespace accumulators
          result_type result(Args const &) const
          {
             return mean_;
+         }
+        
+         // make this accumulator serializeable
+         template<class Archive>
+         void serialize(Archive & ar, const unsigned int file_version)
+         { 
+            ar & mean_;
          }
 
       private:

--- a/include/boost/accumulators/statistics/rolling_moment.hpp
+++ b/include/boost/accumulators/statistics/rolling_moment.hpp
@@ -58,6 +58,13 @@ namespace impl
             return numeric::fdiv(this->sum_, rolling_count(args));
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & sum_;
+        }
+
     private:
         result_type sum_;
     };

--- a/include/boost/accumulators/statistics/rolling_sum.hpp
+++ b/include/boost/accumulators/statistics/rolling_sum.hpp
@@ -51,6 +51,13 @@ namespace impl
             return this->sum_;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & sum_;
+        }
+
     private:
         Sample sum_;
     };

--- a/include/boost/accumulators/statistics/rolling_variance.hpp
+++ b/include/boost/accumulators/statistics/rolling_variance.hpp
@@ -62,6 +62,10 @@ namespace impl
             if (nr_samples < 2) return result_type();
             return nr_samples*(rolling_moment<2>(args) - mean*mean)/(nr_samples-1);
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 
     //! Iterative calculation of the rolling variance.
@@ -137,6 +141,14 @@ namespace impl
             size_t nr_samples = rolling_count(args);
             if (nr_samples < 2) return result_type();
             return numeric::fdiv(sum_of_squares_,(nr_samples-1));
+        }
+        
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & previous_mean_;
+            ar & sum_of_squares_;
         }
 
     private:

--- a/include/boost/accumulators/statistics/rolling_window.hpp
+++ b/include/boost/accumulators/statistics/rolling_window.hpp
@@ -83,6 +83,8 @@ namespace impl
             return result_type(this->buffer_.begin(), this->buffer_.end());
         }
 
+        // TODO need serialization of circular buffer
+
     private:
         circular_buffer<Sample> buffer_;
     };

--- a/include/boost/accumulators/statistics/rolling_window.hpp
+++ b/include/boost/accumulators/statistics/rolling_window.hpp
@@ -21,6 +21,45 @@
 #include <boost/accumulators/framework/parameters/accumulator.hpp>
 #include <boost/accumulators/numeric/functional.hpp>
 #include <boost/accumulators/statistics_fwd.hpp>
+#include <boost/serialization/split_free.hpp>
+
+namespace boost { namespace serialization {
+
+// implement serialization for boost::circular_buffer
+template <class Archive, class T>
+void save(Archive& ar, const circular_buffer<T>& b, const unsigned int /* version */)
+{
+    typename circular_buffer<T>::size_type size = b.size();
+    ar << b.capacity();
+    ar << size;
+    const typename circular_buffer<T>::const_array_range one = b.array_one();
+    const typename circular_buffer<T>::const_array_range two = b.array_two();
+    ar.save_binary(one.first, one.second*sizeof(T));
+    ar.save_binary(two.first, two.second*sizeof(T));
+}
+
+template <class Archive, class T>
+void load(Archive& ar, circular_buffer<T>& b, const unsigned int /* version */)
+{
+    typename circular_buffer<T>::capacity_type capacity;
+    typename circular_buffer<T>::size_type size;
+    ar >> capacity;
+    b.set_capacity(capacity);
+    ar >> size;
+    b.clear();
+    const typename circular_buffer<T>::pointer buff = new T[size*sizeof(T)];
+    ar.load_binary(buff, size*sizeof(T));
+    b.insert(b.begin(), buff, buff+size);
+    delete[] buff;
+}
+
+template<class Archive, class T>
+inline void serialize(Archive & ar, circular_buffer<T>& b, const unsigned int version)
+{
+    split_free(ar, b, version);
+}
+
+} } // end namespace boost::serialization
 
 namespace boost { namespace accumulators
 {
@@ -83,7 +122,11 @@ namespace impl
             return result_type(this->buffer_.begin(), this->buffer_.end());
         }
 
-        // TODO need serialization of circular buffer
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int version)
+        {
+            ar & buffer_;
+        }
 
     private:
         circular_buffer<Sample> buffer_;
@@ -114,6 +157,10 @@ namespace impl
         {
             return rolling_window_plus1(args).advance_begin(is_rolling_window_plus1_full(args));
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 
 } // namespace impl

--- a/include/boost/accumulators/statistics/skewness.hpp
+++ b/include/boost/accumulators/statistics/skewness.hpp
@@ -65,6 +65,10 @@ namespace impl
                         * std::sqrt( accumulators::moment<2>(args) - mean(args) * mean(args) )
                    );
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 
 } // namespace impl

--- a/include/boost/accumulators/statistics/sum.hpp
+++ b/include/boost/accumulators/statistics/sum.hpp
@@ -51,8 +51,13 @@ namespace impl
             return this->sum;
         }
 
-    private:
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & sum;
+        }
 
+    private:
         Sample sum;
     };
 

--- a/include/boost/accumulators/statistics/sum_kahan.hpp
+++ b/include/boost/accumulators/statistics/sum_kahan.hpp
@@ -66,6 +66,14 @@ struct sum_kahan_impl
       return this->sum;
     }
 
+    // make this accumulator serializeable
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int file_version)
+    { 
+        ar & sum;
+        ar & compensation;
+    }
+
 private:
     Sample sum;
     Sample compensation;

--- a/include/boost/accumulators/statistics/tail.hpp
+++ b/include/boost/accumulators/statistics/tail.hpp
@@ -268,6 +268,17 @@ namespace impl
             std::vector<Sample> const &samples;
         };
 
+    public:
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & is_sorted;
+            ar & indices;
+            ar & samples;
+        }
+
+    private:
         mutable bool is_sorted;
         mutable std::vector<std::size_t> indices;
         std::vector<Sample> samples;

--- a/include/boost/accumulators/statistics/tail_mean.hpp
+++ b/include/boost/accumulators/statistics/tail_mean.hpp
@@ -88,6 +88,10 @@ namespace impl
                      - numeric::fdiv(n, count(args))
                    );
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -159,6 +163,10 @@ namespace impl
                 }
             }
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 
 } // namespace impl

--- a/include/boost/accumulators/statistics/tail_quantile.hpp
+++ b/include/boost/accumulators/statistics/tail_quantile.hpp
@@ -98,6 +98,10 @@ namespace impl
                 }
             }
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 } // namespace impl
 

--- a/include/boost/accumulators/statistics/tail_variate.hpp
+++ b/include/boost/accumulators/statistics/tail_variate.hpp
@@ -18,6 +18,7 @@
 #include <boost/accumulators/framework/depends_on.hpp>
 #include <boost/accumulators/statistics_fwd.hpp>
 #include <boost/accumulators/statistics/tail.hpp>
+#include <boost/serialization/vector.hpp>
 
 namespace boost { namespace accumulators
 {
@@ -69,6 +70,14 @@ namespace impl
             );
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & variates;
+        }
+
+    private:
         std::vector<VariateType> variates;
     };
 

--- a/include/boost/accumulators/statistics/tail_variate_means.hpp
+++ b/include/boost/accumulators/statistics/tail_variate_means.hpp
@@ -27,6 +27,7 @@
 #include <boost/accumulators/statistics/tail_variate.hpp>
 #include <boost/accumulators/statistics/tail_mean.hpp>
 #include <boost/accumulators/statistics/parameters/quantile_probability.hpp>
+#include <boost/serialization/vector.hpp>
 
 #ifdef _MSC_VER
 # pragma warning(push)
@@ -143,6 +144,13 @@ namespace impl
                 }
             }
             return make_iterator_range(this->tail_means_);
+        }
+
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & tail_means_;
         }
 
     private:

--- a/include/boost/accumulators/statistics/variance.hpp
+++ b/include/boost/accumulators/statistics/variance.hpp
@@ -53,6 +53,10 @@ namespace impl
             result_type tmp = mean(args);
             return accumulators::moment<2>(args) - tmp * tmp;
         }
+        
+        // serialization is done by accumulators it depends on
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version) {}
     };
 
     //! Iterative calculation of variance.
@@ -111,6 +115,13 @@ namespace impl
         result_type result(dont_care) const
         {
             return this->variance;
+        }
+
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & variance;
         }
 
     private:

--- a/include/boost/accumulators/statistics/weighted_covariance.hpp
+++ b/include/boost/accumulators/statistics/weighted_covariance.hpp
@@ -97,6 +97,13 @@ namespace impl
             return this->cov_;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & cov_;
+        }
+
     private:
         result_type cov_;
     };

--- a/include/boost/accumulators/statistics/weighted_density.hpp
+++ b/include/boost/accumulators/statistics/weighted_density.hpp
@@ -23,6 +23,8 @@
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/min.hpp>
 #include <boost/accumulators/statistics/density.hpp> // for named parameters density_cache_size and density_num_bins
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/utility.hpp>
 
 namespace boost { namespace accumulators
 {
@@ -169,6 +171,20 @@ namespace impl
 
             // returns a range of pairs
             return make_iterator_range(this->histogram);
+        }
+
+        // make this accumulator serializeable
+        // TODO split to save/load and check on parameters provided in ctor
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & cache_size;
+            ar & cache;
+            ar & num_bins;
+            ar & samples_in_bin;
+            ar & bin_positions;
+            ar & histogram;
+            ar & is_dirty; 
         }
 
     private:

--- a/include/boost/accumulators/statistics/weighted_extended_p_square.hpp
+++ b/include/boost/accumulators/statistics/weighted_extended_p_square.hpp
@@ -28,6 +28,7 @@
 #include <boost/accumulators/statistics/sum.hpp>
 #include <boost/accumulators/statistics/times2_iterator.hpp>
 #include <boost/accumulators/statistics/extended_p_square.hpp>
+#include <boost/serialization/vector.hpp>
 
 namespace boost { namespace accumulators
 {
@@ -249,6 +250,17 @@ namespace impl
                 make_permutation_iterator(this->heights.begin(), idx_begin)
               , make_permutation_iterator(this->heights.begin(), idx_end)
             );
+        }
+
+        // make this accumulator serializeable
+        // TODO: do we need to split to load/save and verify that the parameters did not change?
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & probabilities;
+            ar & heights;
+            ar & actual_positions;
+            ar & desired_positions;
         }
 
     private:

--- a/include/boost/accumulators/statistics/weighted_mean.hpp
+++ b/include/boost/accumulators/statistics/weighted_mean.hpp
@@ -97,6 +97,13 @@ namespace impl
             return this->mean;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & mean;
+        }
+
     private:
         result_type mean;
     };

--- a/include/boost/accumulators/statistics/weighted_median.hpp
+++ b/include/boost/accumulators/statistics/weighted_median.hpp
@@ -106,6 +106,15 @@ namespace impl
             return this->median;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & sum;
+            ar & is_dirty;
+            ar & median;
+        }
+
     private:
         mutable float_type sum;
         mutable bool is_dirty;
@@ -162,6 +171,15 @@ namespace impl
 
             return this->median;
         }
+        
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & is_dirty;
+            ar & median;
+        }
+
     private:
         mutable bool is_dirty;
         mutable float_type median;

--- a/include/boost/accumulators/statistics/weighted_moment.hpp
+++ b/include/boost/accumulators/statistics/weighted_moment.hpp
@@ -60,6 +60,13 @@ namespace impl
             return numeric::fdiv(this->sum, sum_of_weights(args));
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        { 
+            ar & sum;
+        }
+
     private:
         weighted_sample sum;
     };

--- a/include/boost/accumulators/statistics/weighted_p_square_cumul_dist.hpp
+++ b/include/boost/accumulators/statistics/weighted_p_square_cumul_dist.hpp
@@ -221,6 +221,19 @@ namespace impl
             return make_iterator_range(this->histogram);
         }
 
+        // make this accumulator serializeable
+        // TODO split to save/load and check on parameters provided in ctor
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & num_cells;
+            ar & heights;
+            ar & actual_positions;
+            ar & desired_positions;
+            ar & histogram;
+            ar & is_dirty; 
+        }
+
     private:
         std::size_t num_cells;            // number of cells b
         array_type  heights;              // q_i

--- a/include/boost/accumulators/statistics/weighted_p_square_quantile.hpp
+++ b/include/boost/accumulators/statistics/weighted_p_square_quantile.hpp
@@ -208,6 +208,17 @@ namespace impl {
             return this->heights[2];
         }
 
+        // make this accumulator serializeable
+        // TODO split to save/load and check on parameters provided in ctor
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & p;
+            ar & heights;
+            ar & actual_positions;
+            ar & desired_positions;
+        }
+
     private:
         float_type p;                    // the quantile probability p
         array_type heights;              // q_i

--- a/include/boost/accumulators/statistics/weighted_peaks_over_threshold.hpp
+++ b/include/boost/accumulators/statistics/weighted_peaks_over_threshold.hpp
@@ -109,6 +109,19 @@ namespace impl
             return this->fit_parameters_;
         }
 
+        // make this accumulator serializeable
+        // TODO: do we need to split to load/save and verify that threshold did not change?
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & sign_;
+            ar & mu_;
+            ar & sigma2_;
+            ar & threshold_;
+            ar & fit_parameters_;
+            ar & is_dirty_;
+        }
+
     private:
         short sign_;                         // for left tail fitting, mirror the extreme values
         mutable float_type mu_;              // mean of samples above threshold

--- a/include/boost/accumulators/statistics/weighted_sum.hpp
+++ b/include/boost/accumulators/statistics/weighted_sum.hpp
@@ -55,6 +55,13 @@ namespace impl
             return this->weighted_sum_;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & weighted_sum_;
+        }
+
     private:
 
         weighted_sample weighted_sum_;

--- a/include/boost/accumulators/statistics/weighted_sum_kahan.hpp
+++ b/include/boost/accumulators/statistics/weighted_sum_kahan.hpp
@@ -68,6 +68,14 @@ namespace impl
             return this->weighted_sum_;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & weighted_sum_;
+            ar & compensation;
+        }
+
     private:
         weighted_sample weighted_sum_;
         weighted_sample compensation;

--- a/include/boost/accumulators/statistics/weighted_tail_variate_means.hpp
+++ b/include/boost/accumulators/statistics/weighted_tail_variate_means.hpp
@@ -179,6 +179,13 @@ namespace impl
             return make_iterator_range(this->tail_means_);
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & tail_means_;
+        }
+
     private:
 
         mutable array_type tail_means_;

--- a/include/boost/accumulators/statistics/weighted_variance.hpp
+++ b/include/boost/accumulators/statistics/weighted_variance.hpp
@@ -103,6 +103,13 @@ namespace impl
             return this->weighted_variance;
         }
 
+        // make this accumulator serializeable
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int file_version)
+        {
+            ar & weighted_variance;
+        }
+
     private:
         result_type weighted_variance;
     };

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -24,6 +24,8 @@ project
       # MSVC's iterator debugging causes some tests to run forever.
       <toolset>msvc:<iterator_debugging>off
       <toolset>intel-win:<iterator_debugging>off
+      <cxxflags>"-Wno-deprecated-declarations"
+      <library>/boost/serialization
     ;
 
 test-suite "accumulators"

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -50,6 +50,8 @@ test-suite "accumulators"
       [ run rolling_count.cpp ]
       [ run rolling_sum.cpp ]
       [ run rolling_mean.cpp ]
+      [ run rolling_variance.cpp ]
+      [ run rolling_moment.cpp ]
       [ run skewness.cpp ]
       [ run sum.cpp ]
       [ run sum_kahan.cpp ]

--- a/test/count.cpp
+++ b/test/count.cpp
@@ -7,6 +7,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/count.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -36,6 +39,31 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // "persistent" storage
+    std::stringstream ss;
+    {
+        accumulator_set<int, stats<tag::count> > acc;
+        acc(1);
+        acc(1);
+        acc(1);
+        acc(1);
+        BOOST_CHECK_EQUAL(4u, count(acc));
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_set<int, stats<tag::count> > acc;
+    BOOST_CHECK_EQUAL(0u, count(acc));
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_EQUAL(4u, count(acc));
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -43,6 +71,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("count test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/covariance.cpp
+++ b/test/covariance.cpp
@@ -11,6 +11,9 @@
 #include <boost/accumulators/statistics/variates/covariate.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/covariance.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -89,6 +92,36 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // "persistent" storage
+    std::stringstream ss;
+    // tolerance
+    double epsilon = 1e-6;
+    {
+
+        accumulator_set<double, stats<tag::covariance<double, tag::covariate1> > > acc;
+        acc(1., covariate1 = 2.);
+        acc(1., covariate1 = 4.);
+        acc(2., covariate1 = 3.);
+        acc(6., covariate1 = 1.);
+
+
+        BOOST_CHECK_CLOSE((covariance(acc)), -1.75, epsilon);
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_set<double, stats<tag::covariance<double, tag::covariate1> > > acc;
+    BOOST_CHECK_CLOSE((covariance(acc)), 0., epsilon);
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_CLOSE((covariance(acc)), -1.75, epsilon);
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -96,6 +129,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("covariance test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/extended_p_square.cpp
+++ b/test/extended_p_square.cpp
@@ -15,17 +15,21 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/extended_p_square.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
 using namespace boost::accumulators;
+
+typedef accumulator_set<double, stats<tag::extended_p_square> > accumulator_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 // test_stat
 //
 void test_stat()
 {
-    typedef accumulator_set<double, stats<tag::extended_p_square> > accumulator_t;
 
     // tolerance
     double epsilon = 3;
@@ -62,6 +66,36 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // "persistent" storage
+    std::stringstream ss;
+    // tolerance
+    double epsilon = 3.;
+    std::vector<double> probs;
+    probs.push_back(0.75);
+    {
+        accumulator_t acc(extended_p_square_probabilities = probs);
+        // a random number generator
+        boost::lagged_fibonacci607 rng;
+
+        for (int i=0; i<10000; ++i)
+            acc(rng());
+
+        BOOST_CHECK_CLOSE(extended_p_square(acc)[0], probs[0], epsilon);
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_t acc(extended_p_square_probabilities = probs);
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(extended_p_square(acc)[0], probs[0], epsilon);
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -69,6 +103,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("extended_p_square test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/extended_p_square_quantile.cpp
+++ b/test/extended_p_square_quantile.cpp
@@ -15,21 +15,24 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/extended_p_square_quantile.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
 using namespace boost::accumulators;
+
+typedef accumulator_set<double, stats<tag::extended_p_square_quantile> > accumulator_t;
+typedef accumulator_set<double, stats<tag::weighted_extended_p_square_quantile>, double > accumulator_t_weighted;
+typedef accumulator_set<double, stats<tag::extended_p_square_quantile(quadratic)> > accumulator_t_quadratic;
+typedef accumulator_set<double, stats<tag::weighted_extended_p_square_quantile(quadratic)>, double > accumulator_t_weighted_quadratic;
 
 ///////////////////////////////////////////////////////////////////////////////
 // test_stat
 //
 void test_stat()
 {
-    typedef accumulator_set<double, stats<tag::extended_p_square_quantile> > accumulator_t;
-    typedef accumulator_set<double, stats<tag::weighted_extended_p_square_quantile>, double > accumulator_t_weighted;
-    typedef accumulator_set<double, stats<tag::extended_p_square_quantile(quadratic)> > accumulator_t_quadratic;
-    typedef accumulator_set<double, stats<tag::weighted_extended_p_square_quantile(quadratic)>, double > accumulator_t_weighted_quadratic;
-
     // tolerance
     double epsilon = 1;
 
@@ -89,6 +92,74 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // "persistent" storage
+    std::stringstream ss;
+    
+    // tolerance
+    double epsilon = 1.;
+    
+    // a random number generator
+    boost::lagged_fibonacci607 rng;
+
+    std::vector<double> probs;
+    probs.push_back(0.990);
+    probs.push_back(0.991);
+    probs.push_back(0.992);
+    probs.push_back(0.993);
+    probs.push_back(0.994);
+    probs.push_back(0.995);
+    probs.push_back(0.996);
+    probs.push_back(0.997);
+    probs.push_back(0.998);
+    probs.push_back(0.999);
+
+    {
+        accumulator_t acc(extended_p_square_probabilities = probs);
+        accumulator_t_weighted acc_weighted(extended_p_square_probabilities = probs);
+
+        for (int i=0; i<10000; ++i)
+        {
+            double sample = rng();
+            acc(sample);
+            acc_weighted(sample, weight = 1.);
+        }
+
+        BOOST_CHECK_CLOSE(
+            quantile(acc, quantile_probability = 0.99025)
+          , 0.99025
+          , epsilon
+        );
+        BOOST_CHECK_CLOSE(
+            quantile(acc_weighted, quantile_probability = 0.99025)
+          , 0.99025
+          , epsilon
+        );
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+        acc_weighted.serialize(oa, 0);
+    }
+
+    accumulator_t acc(extended_p_square_probabilities = probs);
+    accumulator_t_weighted acc_weighted(extended_p_square_probabilities = probs);
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    acc_weighted.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(
+        quantile(acc, quantile_probability = 0.99025)
+      , 0.99025
+      , epsilon
+    );
+    BOOST_CHECK_CLOSE(
+        quantile(acc_weighted, quantile_probability = 0.99025)
+      , 0.99025
+      , epsilon
+    );
+}
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -96,6 +167,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("extended_p_square_quantile test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/kurtosis.cpp
+++ b/test/kurtosis.cpp
@@ -14,6 +14,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/kurtosis.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -57,6 +60,34 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // "persistent" storage
+    std::stringstream ss;
+    // tolerance
+    double epsilon = 1e-6;
+    double kurtosis_value = -1.39965397924;
+    {
+        accumulator_set<int, stats<tag::kurtosis > > acc;
+        acc(2);
+        acc(7);
+        acc(4);
+        acc(9);
+        acc(3);
+        BOOST_CHECK_CLOSE( kurtosis(acc), kurtosis_value, epsilon);
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+
+    accumulator_set<double, stats<tag::kurtosis > > acc;
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_CLOSE( kurtosis(acc), kurtosis_value, epsilon);
+
+}
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -64,6 +95,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("kurtosis test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/max.cpp
+++ b/test/max.cpp
@@ -51,7 +51,6 @@ void test_persistency()
     boost::archive::text_iarchive ia(ss);
     acc.serialize(ia, 0);
     BOOST_CHECK_EQUAL(2u, max(acc));
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/max.cpp
+++ b/test/max.cpp
@@ -7,6 +7,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/max.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -30,6 +33,28 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    std::stringstream ss;
+    {
+        accumulator_set<int, stats<tag::max> > acc;
+        acc(1);
+        acc(0);
+        acc(2);
+        BOOST_CHECK_EQUAL(2u, max(acc));
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_set<int, stats<tag::max> > acc;
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_EQUAL(2u, max(acc));
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -37,6 +62,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("max test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/mean.cpp
+++ b/test/mean.cpp
@@ -9,6 +9,9 @@
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/weighted_mean.hpp>
 #include <boost/accumulators/statistics/variates/covariate.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -20,18 +23,18 @@ void assert_is_double(T const &)
     BOOST_MPL_ASSERT((is_same<T, double>));
 }
 
+typedef accumulator_set<int, stats<tag::mean, 
+        tag::mean_of_variates<int, tag::covariate1> > > mean_t;
+
+typedef accumulator_set<int, stats<tag::mean(immediate), 
+        tag::mean_of_variates<int, tag::covariate1>(immediate) > > immediate_mean_t;
+
 ///////////////////////////////////////////////////////////////////////////////
 // test_stat
 //
 void test_stat()
 {
-    accumulator_set<
-        int
-      , stats<
-            tag::mean
-          , tag::mean_of_variates<int, tag::covariate1>
-        >
-    > acc, test_acc(sample = 0);
+    mean_t acc, test_acc(sample = 0);
 
     acc(1, covariate1 = 3);
     BOOST_CHECK_CLOSE(1., mean(acc), 1e-5);
@@ -53,13 +56,7 @@ void test_stat()
 
     assert_is_double(mean(acc));
 
-    accumulator_set<
-        int
-      , stats<
-            tag::mean(immediate)
-          , tag::mean_of_variates<int, tag::covariate1>(immediate)
-        >
-    > acc2, test_acc2(sample = 0);
+    immediate_mean_t acc2, test_acc2(sample = 0);
 
     acc2(1, covariate1 = 3);
     BOOST_CHECK_CLOSE(1., mean(acc2), 1e-5);
@@ -80,6 +77,39 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    std::stringstream ss;
+    {
+        mean_t acc1;
+        immediate_mean_t acc2;
+
+        acc1(1, covariate1 = 3);
+        acc1(0, covariate1 = 4);
+        acc1(2, covariate1 = 8);
+        acc2(1, covariate1 = 3);
+        acc2(0, covariate1 = 4);
+        acc2(2, covariate1 = 8);
+        BOOST_CHECK_CLOSE(1., mean(acc1), 1e-5);
+        BOOST_CHECK_CLOSE(5., (accumulators::mean_of_variates<int, tag::covariate1>(acc1)), 1e-5);
+        BOOST_CHECK_CLOSE(1., mean(acc2), 1e-5);
+        BOOST_CHECK_CLOSE(5., (accumulators::mean_of_variates<int, tag::covariate1>(acc2)), 1e-5);
+        boost::archive::text_oarchive oa(ss);
+        acc1.serialize(oa, 0);
+        acc2.serialize(oa, 0);
+    }
+    mean_t acc1;
+    immediate_mean_t acc2;
+    boost::archive::text_iarchive ia(ss);
+    acc1.serialize(ia, 0);
+    acc2.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(1., mean(acc1), 1e-5);
+    BOOST_CHECK_CLOSE(5., (accumulators::mean_of_variates<int, tag::covariate1>(acc2)), 1e-5);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -87,6 +117,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("mean test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/median.cpp
+++ b/test/median.cpp
@@ -9,10 +9,18 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/median.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
 using namespace accumulators;
+
+
+typedef accumulator_set<double, stats<tag::median(with_p_square_quantile) > > p_square_median_t;
+typedef accumulator_set<double, stats<tag::median(with_density) > > dist_median_t;
+typedef accumulator_set<double, stats<tag::median(with_p_square_cumulative_distribution) > > p_square_dist_median_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 // test_stat
@@ -25,11 +33,9 @@ void test_stat()
     boost::normal_distribution<> mean_sigma(mu,1);
     boost::variate_generator<boost::lagged_fibonacci607&, boost::normal_distribution<> > normal(rng, mean_sigma);
 
-    accumulator_set<double, stats<tag::median(with_p_square_quantile) > > acc;
-    accumulator_set<double, stats<tag::median(with_density) > >
-        acc_dens( density_cache_size = 10000, density_num_bins = 1000 );
-    accumulator_set<double, stats<tag::median(with_p_square_cumulative_distribution) > >
-        acc_cdist( p_square_cumulative_distribution_num_cells = 100 );
+    p_square_median_t acc;
+    dist_median_t acc_dens( density_cache_size = 10000, density_num_bins = 1000 );
+    p_square_dist_median_t acc_cdist( p_square_cumulative_distribution_num_cells = 100 );
 
     for (std::size_t i=0; i<100000; ++i)
     {
@@ -45,6 +51,52 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // two random number generators
+    double mu = 1.;
+    boost::lagged_fibonacci607 rng;
+    boost::normal_distribution<> mean_sigma(mu,1);
+    boost::variate_generator<boost::lagged_fibonacci607&, boost::normal_distribution<> > normal(rng, mean_sigma);
+    std::stringstream ss;
+    {
+        p_square_median_t acc;
+        dist_median_t acc_dens( density_cache_size = 10000, density_num_bins = 1000 );
+        p_square_dist_median_t acc_cdist( p_square_cumulative_distribution_num_cells = 100 );
+
+        for (std::size_t i=0; i<100000; ++i)
+        {
+            double sample = normal();
+            acc(sample);
+            acc_dens(sample);
+            acc_cdist(sample);
+        }
+
+        BOOST_CHECK_CLOSE(1., median(acc), 1.);
+        BOOST_CHECK_CLOSE(1., median(acc_dens), 1.);
+        BOOST_CHECK_CLOSE(1., median(acc_cdist), 3.);
+
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+        acc_dens.serialize(oa, 0);
+        acc_cdist.serialize(oa, 0);
+    }
+
+    p_square_median_t acc;
+    dist_median_t acc_dens( density_cache_size = 10000, density_num_bins = 1000 );
+    p_square_dist_median_t acc_cdist( p_square_cumulative_distribution_num_cells = 100 );
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    acc_dens.serialize(ia, 0);
+    acc_cdist.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(1., median(acc), 1.);
+    BOOST_CHECK_CLOSE(1., median(acc_dens), 1.);
+    BOOST_CHECK_CLOSE(1., median(acc_cdist), 3.);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -52,6 +104,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("median test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/min.cpp
+++ b/test/min.cpp
@@ -7,6 +7,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/min.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -30,6 +33,27 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    std::stringstream ss;
+    {
+        accumulator_set<int, stats<tag::min> > acc;
+        acc(1);
+        acc(0);
+        acc(2);
+        BOOST_CHECK_EQUAL(0, (min)(acc));
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_set<int, stats<tag::min> > acc;
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_EQUAL(0, (min)(acc));
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -37,6 +61,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("min test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/moment.cpp
+++ b/test/moment.cpp
@@ -8,6 +8,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/moment.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -39,6 +42,29 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    double epsilon = 1e-5;
+    std::stringstream ss;
+    {
+        accumulator_set<int, stats<tag::moment<2> > > acc;
+        acc(2); //    4
+        acc(4); //   16
+        acc(5); // + 25
+                 // = 45 / 3 = 15
+        BOOST_CHECK_CLOSE(15., accumulators::moment<2>(acc), epsilon);
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_set<int, stats<tag::moment<2> > > acc;
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(15., accumulators::moment<2>(acc), epsilon);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -46,6 +72,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("moment test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/p_square_cumul_dist.cpp
+++ b/test/p_square_cumul_dist.cpp
@@ -15,6 +15,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/p_square_cumul_dist.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -34,6 +37,9 @@ double my_erf(double const& x, int const& n = 1000)
     return sum * 2. / std::sqrt(3.141592653);
 }
 
+typedef accumulator_set<double, stats<tag::p_square_cumulative_distribution> > accumulator_t;
+typedef iterator_range<std::vector<std::pair<double, double> >::iterator > histogram_type;
+
 ///////////////////////////////////////////////////////////////////////////////
 // test_stat
 //
@@ -42,8 +48,6 @@ void test_stat()
     // tolerance in %
     double epsilon = 3;
 
-    typedef accumulator_set<double, stats<tag::p_square_cumulative_distribution> > accumulator_t;
-
     accumulator_t acc(p_square_cumulative_distribution_num_cells = 100);
 
     // two random number generators
@@ -51,12 +55,11 @@ void test_stat()
     boost::normal_distribution<> mean_sigma(0,1);
     boost::variate_generator<boost::lagged_fibonacci607&, boost::normal_distribution<> > normal(rng, mean_sigma);
 
-    for (std::size_t i=0; i<100000; ++i)
+    for (std::size_t i=0; i<1000000; ++i)
     {
         acc(normal());
     }
 
-    typedef iterator_range<std::vector<std::pair<double, double> >::iterator > histogram_type;
     histogram_type histogram = p_square_cumulative_distribution(acc);
 
     for (std::size_t i = 0; i < histogram.size(); ++i)
@@ -68,6 +71,45 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // "persistent" storage
+    std::stringstream ss;
+    // tolerance in %
+    double epsilon = 3;
+    {
+        accumulator_t acc(p_square_cumulative_distribution_num_cells = 100);
+
+        // two random number generators
+        boost::lagged_fibonacci607 rng;
+        boost::normal_distribution<> mean_sigma(0,1);
+        boost::variate_generator<boost::lagged_fibonacci607&, boost::normal_distribution<> > normal(rng, mean_sigma);
+
+        for (std::size_t i=0; i<1000000; ++i)
+        {
+            acc(normal());
+        }
+
+        histogram_type histogram = p_square_cumulative_distribution(acc);
+
+        BOOST_CHECK_CLOSE(0.5 * (1.0 + my_erf(histogram[25].first / std::sqrt(2.0))), histogram[25].second, epsilon);
+        BOOST_CHECK_CLOSE(0.5 * (1.0 + my_erf(histogram[50].first / std::sqrt(2.0))), histogram[50].second, epsilon);
+        BOOST_CHECK_CLOSE(0.5 * (1.0 + my_erf(histogram[75].first / std::sqrt(2.0))), histogram[75].second, epsilon);
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_t acc(p_square_cumulative_distribution_num_cells = 100);
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    histogram_type histogram = p_square_cumulative_distribution(acc);
+    BOOST_CHECK_CLOSE(0.5 * (1.0 + my_erf(histogram[25].first / std::sqrt(2.0))), histogram[25].second, epsilon);
+    BOOST_CHECK_CLOSE(0.5 * (1.0 + my_erf(histogram[50].first / std::sqrt(2.0))), histogram[50].second, epsilon);
+    BOOST_CHECK_CLOSE(0.5 * (1.0 + my_erf(histogram[75].first / std::sqrt(2.0))), histogram[75].second, epsilon);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -75,6 +117,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("p_square_cumulative_distribution test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/p_square_quantile.cpp
+++ b/test/p_square_quantile.cpp
@@ -14,18 +14,21 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/p_square_quantile.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
 using namespace boost::accumulators;
+
+typedef accumulator_set<double, stats<tag::p_square_quantile> > accumulator_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 // test_stat
 //
 void test_stat()
 {
-    typedef accumulator_set<double, stats<tag::p_square_quantile> > accumulator_t;
-
     // tolerance in %
     double epsilon = 1;
 
@@ -68,6 +71,43 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // "persistent" storage
+    std::stringstream ss;
+    // tolerance in %
+    double epsilon = 1;
+    // a random number generator
+    boost::lagged_fibonacci607 rng;
+    {
+        accumulator_t acc1(quantile_probability = 0.75 );
+        accumulator_t acc2(quantile_probability = 0.999);
+
+        for (int i=0; i<100000; ++i)
+        {
+            double sample = rng();
+            acc1(sample);
+            acc2(sample);
+        }
+
+        BOOST_CHECK_CLOSE(p_square_quantile(acc1), 0.75 , epsilon);
+        BOOST_CHECK_CLOSE(p_square_quantile(acc2), 0.999, epsilon);
+        boost::archive::text_oarchive oa(ss);
+        acc1.serialize(oa, 0);
+        acc2.serialize(oa, 0);
+    }
+    accumulator_t acc1(quantile_probability = 0.75);
+    accumulator_t acc2(quantile_probability = 0.999);
+    boost::archive::text_iarchive ia(ss);
+    acc1.serialize(ia, 0);
+    acc2.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(p_square_quantile(acc1), 0.75 , epsilon);
+    BOOST_CHECK_CLOSE(p_square_quantile(acc2), 0.999, epsilon);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -75,6 +115,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("p_square_quantile test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/p_square_quantile_extended.cpp
+++ b/test/p_square_quantile_extended.cpp
@@ -15,18 +15,21 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/p_square_quantile_extended.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
 using namespace boost::accumulators;
+
+typedef accumulator_set<double, stats<tag::p_square_quantile_extended> > accumulator_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 // test_stat
 //
 void test_stat()
 {
-    typedef accumulator_set<double, stats<tag::p_square_quantile_extended> > accumulator_t;
-
     // tolerance
     double epsilon = 1e-6;
 
@@ -57,6 +60,49 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // "persistent" storage
+    std::stringstream ss;
+    // tolerance in %
+    double epsilon = 1;
+    // a random number generator
+    boost::lagged_fibonacci607 rng;
+
+    std::vector<double> probs;
+    probs.push_back(0.001);
+    probs.push_back(0.01 );
+    probs.push_back(0.1  );
+    probs.push_back(0.25 );
+    probs.push_back(0.5  );
+    probs.push_back(0.75 );
+    probs.push_back(0.9  );
+    probs.push_back(0.99 );
+    probs.push_back(0.999);
+    {
+        accumulator_t acc(tag::p_square_quantile_extended::probabilities = probs);
+
+        for (int i=0; i<10000; ++i)
+            acc(rng());
+
+        for (std::size_t i=0; i<probs.size(); ++i)
+        {
+            BOOST_CHECK_CLOSE(p_square_quantile_extended(acc)[i], probs[i], epsilon);
+        }
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_t acc(tag::p_square_quantile_extended::probabilities = probs);
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    for (std::size_t i=0; i<probs.size(); ++i)
+    {
+        BOOST_CHECK_CLOSE(p_square_quantile_extended(acc)[i], probs[i], epsilon);
+    }
+}
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -64,6 +110,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("p_square_quantile_extended test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/pot_quantile.cpp
+++ b/test/pot_quantile.cpp
@@ -15,6 +15,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
 #include <boost/accumulators/statistics/peaks_over_threshold.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -84,6 +87,36 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // tolerance in %
+    double epsilon = 1.;
+    // "persistent" storage
+    std::stringstream ss;
+    {
+        // random number generators
+        boost::lagged_fibonacci607 rng;
+        boost::normal_distribution<> mean_sigma(0,1);
+        boost::variate_generator<boost::lagged_fibonacci607&, boost::normal_distribution<> > normal(rng, mean_sigma);
+
+        accumulator_set<double, stats<tag::pot_quantile<right>(with_threshold_value)> > acc(pot_threshold_value = 3.);
+
+        for (std::size_t i = 0; i < 100000; ++i)
+            acc(normal());
+
+        BOOST_CHECK_CLOSE(quantile(acc, quantile_probability = 0.999), 3.090232, 3*epsilon);
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_set<double, stats<tag::pot_quantile<right>(with_threshold_value)> > acc(pot_threshold_value = 3.);
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(quantile(acc, quantile_probability = 0.999), 3.090232, 3*epsilon);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -91,6 +124,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("pot_quantile test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/rolling_count.cpp
+++ b/test/rolling_count.cpp
@@ -7,6 +7,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/rolling_count.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -38,6 +41,30 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    std::stringstream ss;
+    {
+        accumulator_set<int, stats<tag::rolling_count> > acc(tag::rolling_window::window_size = 3);
+        acc(1);
+        acc(1);
+        acc(1);
+        acc(1);
+        acc(1);
+        acc(1);
+        BOOST_CHECK_EQUAL(3u, rolling_count(acc));
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_set<int, stats<tag::rolling_count> > acc(tag::rolling_window::window_size = 3);
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_EQUAL(3u, rolling_count(acc));
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -45,6 +72,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("rolling count test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/rolling_mean.cpp
+++ b/test/rolling_mean.cpp
@@ -11,6 +11,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/rolling_mean.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -52,6 +55,39 @@ test_rolling_mean_test_impl(accumulator_set_type& acc)
     BOOST_CHECK_CLOSE(5., rolling_mean(acc), 1e-5);
 
     assert_is_double(rolling_mean(acc));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// test_persistency_impl
+//
+template<typename accumulator_set_type>
+void test_persistency_impl(accumulator_set_type& acc)
+{
+    std::stringstream ss;
+    {
+        acc(1);
+        acc(2);
+        acc(3);
+        acc(4);
+        acc(5);
+        acc(6);
+        acc(7);
+        BOOST_CHECK_CLOSE(5., rolling_mean(acc), 1e-5);
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    // initialize from acc to make sure all values are passed
+    accumulator_set_type other_acc = acc;
+    // accumulate more, to make sure that deserialization set the right value
+    // and not the copy ctor
+    other_acc(100);
+    other_acc(100);
+    other_acc(100);
+    other_acc(100);
+    other_acc(100);
+    boost::archive::text_iarchive ia(ss);
+    other_acc.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(5., rolling_mean(other_acc), 1e-5);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -100,6 +136,40 @@ void test_rolling_mean()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+void test_persistency()
+{
+    accumulator_set<int,stats<tag::immediate_rolling_mean> >
+        acc_immediate_rolling_mean(tag::immediate_rolling_mean::window_size = window_size),
+        acc_immediate_rolling_mean2(tag::immediate_rolling_mean::window_size = window_size, sample = 0);
+
+    accumulator_set<int,stats<tag::rolling_mean(immediate)> >
+       acc_immediate_rolling_mean3(tag::immediate_rolling_mean::window_size = window_size);
+
+    accumulator_set<int,stats<tag::lazy_rolling_mean> >
+        acc_lazy_rolling_mean(tag::lazy_rolling_mean::window_size = window_size),
+        acc_lazy_rolling_mean2(tag::lazy_rolling_mean::window_size = window_size, sample = 0);
+
+    accumulator_set<int,stats<tag::rolling_mean(lazy)> >
+       acc_lazy_rolling_mean3(tag::lazy_rolling_mean::window_size = window_size);
+
+    accumulator_set<int,stats<tag::rolling_mean> >
+        acc_default_rolling_mean(tag::rolling_mean::window_size = window_size),
+        acc_default_rolling_mean2(tag::rolling_mean::window_size = window_size, sample = 0);
+
+    //// test the different implementations
+    test_persistency_impl(acc_lazy_rolling_mean);
+    test_persistency_impl(acc_default_rolling_mean);
+    test_persistency_impl(acc_immediate_rolling_mean);
+
+    test_persistency_impl(acc_lazy_rolling_mean2);
+    test_persistency_impl(acc_default_rolling_mean2);
+    test_persistency_impl(acc_immediate_rolling_mean2);
+
+    test_persistency_impl(acc_lazy_rolling_mean3);
+    test_persistency_impl(acc_immediate_rolling_mean3);
+}
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -107,6 +177,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("rolling mean test");
 
     test->add(BOOST_TEST_CASE(&test_rolling_mean));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/rolling_moment.cpp
+++ b/test/rolling_moment.cpp
@@ -10,6 +10,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/rolling_moment.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -72,6 +75,36 @@ void test_rolling_fifth_moment()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    std::stringstream ss;
+    {
+        accumulator_set<int, stats<tag::rolling_moment<2> > > acc2(tag::rolling_moment<2>::window_size = 3);
+        accumulator_set<int, stats<tag::rolling_moment<5> > > acc5(tag::rolling_moment<5>::window_size = 3);
+
+        acc2(2); acc5(2);
+        acc2(4); acc5(3);
+        acc2(5); acc5(4);
+        acc2(6); acc5(5);
+
+        BOOST_CHECK_CLOSE(rolling_moment<2>(acc2), (16.0 + 25.0 + 36.0)/3, 1e-5);
+        BOOST_CHECK_CLOSE(rolling_moment<5>(acc5), (243.0 + 1024.0 + 3125.0)/3, 1e-5);
+        boost::archive::text_oarchive oa(ss);
+        acc2.serialize(oa, 0);
+        acc5.serialize(oa, 0);
+    }
+    accumulator_set<int, stats<tag::rolling_moment<2> > > acc2(tag::rolling_moment<2>::window_size = 3);
+    accumulator_set<int, stats<tag::rolling_moment<5> > > acc5(tag::rolling_moment<5>::window_size = 3);
+    boost::archive::text_iarchive ia(ss);
+    acc2.serialize(ia, 0);
+    acc5.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(rolling_moment<2>(acc2), (16.0 + 25.0 + 36.0)/3, 1e-5);
+    BOOST_CHECK_CLOSE(rolling_moment<5>(acc5), (243.0 + 1024.0 + 3125.0)/3, 1e-5);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -80,6 +113,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
 
     test->add(BOOST_TEST_CASE(&test_rolling_second_moment));
     test->add(BOOST_TEST_CASE(&test_rolling_fifth_moment));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/rolling_variance.cpp
+++ b/test/rolling_variance.cpp
@@ -9,7 +9,9 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
-
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 #include <boost/accumulators/statistics/rolling_variance.hpp>
 
 using namespace boost;
@@ -133,6 +135,66 @@ void test_rolling_variance()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency_impl
+//
+template<typename accumulator_set_type>
+void test_persistency_impl(accumulator_set_type& acc)
+{
+    std::stringstream ss;
+    {
+        acc(1.2);
+        acc(2.3);
+        acc(3.4);
+        acc(4.5);
+        acc(0.4);
+        acc(2.2);
+        acc(7.1);
+        acc(4.0);
+        BOOST_CHECK_CLOSE(rolling_variance(acc),8.16250000000000,1e-10);
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_set_type other_acc = acc;
+    boost::archive::text_iarchive ia(ss);
+    other_acc.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(rolling_variance(acc),8.16250000000000,1e-10);
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    // tag::rolling_window::window_size
+    accumulator_set<double, stats<tag::immediate_rolling_variance> >
+        acc_immediate_rolling_variance(tag::immediate_rolling_variance::window_size = window_size);
+
+    accumulator_set<double, stats<tag::immediate_rolling_variance, tag::rolling_mean> >
+        acc_immediate_rolling_variance2(tag::immediate_rolling_variance::window_size = window_size);
+
+    accumulator_set<double, stats<tag::rolling_variance(immediate)> >
+        acc_immediate_rolling_variance3(tag::immediate_rolling_variance::window_size = window_size);
+
+    accumulator_set<double, stats<tag::lazy_rolling_variance> >
+        acc_lazy_rolling_variance(tag::lazy_rolling_variance::window_size = window_size);
+
+    accumulator_set<double, stats<tag::rolling_variance(lazy)> >
+       acc_lazy_rolling_variance2(tag::immediate_rolling_variance::window_size = window_size);
+
+    accumulator_set<double, stats<tag::rolling_variance> >
+        acc_default_rolling_variance(tag::rolling_variance::window_size = window_size);
+
+    //// test the different implementations
+    test_persistency_impl(acc_immediate_rolling_variance);
+    test_persistency_impl(acc_immediate_rolling_variance2);
+    test_persistency_impl(acc_immediate_rolling_variance3);
+    test_persistency_impl(acc_lazy_rolling_variance);
+    test_persistency_impl(acc_lazy_rolling_variance2);
+    test_persistency_impl(acc_default_rolling_variance);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -140,6 +202,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("rolling variance test");
 
     test->add(BOOST_TEST_CASE(&test_rolling_variance));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/skewness.cpp
+++ b/test/skewness.cpp
@@ -14,6 +14,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/skewness.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -56,6 +59,33 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    double epsilon = 1e-6;
+    std::stringstream ss;
+    {
+        accumulator_set<int, stats<tag::skewness > > acc;
+        acc(2);
+        acc(7);
+        acc(4);
+        acc(9);
+        acc(3);
+
+        BOOST_CHECK_EQUAL(accumulators::moment<3>(acc), 1171./5.);
+        BOOST_CHECK_CLOSE(skewness(acc), 0.406040288214, epsilon);
+        boost::archive::text_oarchive oa(ss);
+        acc.serialize(oa, 0);
+    }
+    accumulator_set<int, stats<tag::skewness > > acc;
+    boost::archive::text_iarchive ia(ss);
+    acc.serialize(ia, 0);
+    BOOST_CHECK_EQUAL(accumulators::moment<3>(acc), 1171./5.);
+    BOOST_CHECK_CLOSE(skewness(acc), 0.406040288214, epsilon);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -63,6 +93,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("skewness test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/variance.cpp
+++ b/test/variance.cpp
@@ -8,6 +8,9 @@
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 
 using namespace boost;
 using namespace unit_test;
@@ -56,6 +59,41 @@ void test_stat()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test_persistency
+//
+void test_persistency()
+{
+    double epsilon = 1e-5;
+    std::stringstream ss;
+    {
+        accumulator_set<int, stats<tag::variance(lazy)> > acc1;
+        accumulator_set<int, stats<tag::variance> > acc2;
+        acc1(1);
+        acc1(2);
+        acc1(3);
+        acc1(4);
+        acc1(5);
+        acc2(1);
+        acc2(2);
+        acc2(3);
+        acc2(4);
+        acc2(5);
+        BOOST_CHECK_CLOSE(2., variance(acc2), epsilon);
+        BOOST_CHECK_CLOSE(2., variance(acc1), epsilon);
+        boost::archive::text_oarchive oa(ss);
+        acc1.serialize(oa, 0);
+        acc2.serialize(oa, 0);
+    }
+    accumulator_set<int, stats<tag::variance(lazy)> > acc1;
+    accumulator_set<int, stats<tag::variance> > acc2;
+    boost::archive::text_iarchive ia(ss);
+    acc1.serialize(ia, 0);
+    acc2.serialize(ia, 0);
+    BOOST_CHECK_CLOSE(2., variance(acc2), epsilon);
+    BOOST_CHECK_CLOSE(2., variance(acc1), epsilon);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // init_unit_test_suite
 //
 test_suite* init_unit_test_suite( int argc, char* argv[] )
@@ -63,6 +101,7 @@ test_suite* init_unit_test_suite( int argc, char* argv[] )
     test_suite *test = BOOST_TEST_SUITE("variance test");
 
     test->add(BOOST_TEST_CASE(&test_stat));
+    test->add(BOOST_TEST_CASE(&test_persistency));
 
     return test;
 }

--- a/test/weighted_median.cpp
+++ b/test/weighted_median.cpp
@@ -38,7 +38,7 @@ void test_stat()
         acc_cdist( p_square_cumulative_distribution_num_cells = 100 );
 
 
-    for (std::size_t i=0; i<100000; ++i)
+    for (std::size_t i=0; i<1000000; ++i)
     {
         double sample = normal_narrow();
         acc(sample, weight = std::exp(0.5 * (sample - mu) * (sample - mu) * ( 1./sigma_narrow/sigma_narrow - 1./sigma/sigma )));


### PR DESCRIPTION
This PR is meant to address [this](https://stackoverflow.com/questions/32289719/how-to-serialize-boostaccumulatorsaccumulator-set) request (also tracked as issue #13).
The great value from accumulators is the fact there is no need to store large amounts of raw data, in order to get the statistics. Allowing serialization of internal state, so that the process accumulating the stats, could stop and continue from where it left off, would allow for more scenarios to use accumulators without the need to store the raw data.
> 1. there should be no perf impact on regular operation of the accumulators
> 2. ~~rolling stats are not serializeable yet (more work is needed for serializing the circular buffer)~~
> 3. In some cases, the ctor parameters are stored inside the accumulator, so, when deserialized they are overwritten. Was not sure if this is what would be the expected behavior?
> 4. made some loops longer to fix flaky tests (unrelated to this PR), addressing issue #12
