### PR TITLE
remove Boost::numeric_ublas dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(boost_accumulators
     Boost::iterator
     Boost::mpl
     Boost::numeric_conversion
-    Boost::numeric_ublas
     Boost::parameter
     Boost::preprocessor
     Boost::range


### PR DESCRIPTION
Resolves #55 

I have not looked into whether this change would be tested with any existing tests. LMK if there is some test that should accompany this change.
