### PR TITLE
Update GHA CI to be generic with cpp-actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,257 +8,117 @@ on:
       - develop
       - feature/**
 
-env:
-  UBSAN_OPTIONS: print_stacktrace=1
-
 jobs:
-  posix:
+  cpp-matrix:
+    runs-on: ubuntu-latest
+    name: Generate Test Matrix
+    outputs:
+      matrix: ${{ steps.cpp-matrix.outputs.matrix }}
+    steps:
+      - name: Generate Test Matrix
+        uses: alandefreitas/cpp-actions/cpp-matrix@master
+        id: cpp-matrix
+        with:
+          extra-values: |
+            boost-lib: accumulators
+            scan-dirs: test
+          compilers: |
+            gcc >= 4.8
+            clang >= 3.9
+            msvc >= 14.0
+            apple-clang *
+            mingw *
+            clang-cl *
+          standards: '>=11'
+          latest-factors: |
+            gcc Asan TSan UBSan
+            clang BoundsSan IntSan
+          factors: |
+            gcc Shared
+            msvc Shared x86
+            mingw Shared
+          subrange-policy: |
+            msvc: one-per-minor
+          trace-commands: true
+  build:
+    needs: cpp-matrix
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - toolset: gcc-4.8
-            cxxstd: "11"
-            os: ubuntu-latest
-            container: ubuntu:18.04
-            install: g++-4.8
-          - toolset: gcc-5
-            cxxstd: "11,14,1z"
-            os: ubuntu-latest
-            container: ubuntu:18.04
-            install: g++-5
-          - toolset: gcc-6
-            cxxstd: "11,14,1z"
-            os: ubuntu-latest
-            container: ubuntu:18.04
-            install: g++-6
-          - toolset: gcc-7
-            cxxstd: "11,14,17"
-            os: ubuntu-20.04
-            install: g++-7
-          - toolset: gcc-8
-            cxxstd: "11,14,17,2a"
-            os: ubuntu-20.04
-            install: g++-8
-          - toolset: gcc-9
-            cxxstd: "11,14,17,2a"
-            os: ubuntu-20.04
-          - toolset: gcc-10
-            cxxstd: "11,14,17,2a"
-            os: ubuntu-20.04
-            install: g++-10
-          - toolset: gcc-11
-            cxxstd: "11,14,17,2a"
-            os: ubuntu-20.04
-            install: g++-11
-          - toolset: gcc-12
-            cxxstd: "11,14,17,20,2b"
-            os: ubuntu-22.04
-            install: g++-12
-          - toolset: gcc-13
-            cxxstd: "11,14,17,20,2b"
-            os: ubuntu-latest
-            container: ubuntu:23.04
-            install: g++-13
-          - toolset: clang
-            compiler: clang++-3.9
-            cxxstd: "11,14"
-            os: ubuntu-latest
-            container: ubuntu:18.04
-            install: clang-3.9
-          - toolset: clang
-            compiler: clang++-4.0
-            cxxstd: "11,14"
-            os: ubuntu-latest
-            container: ubuntu:18.04
-            install: clang-4.0
-          - toolset: clang
-            compiler: clang++-5.0
-            cxxstd: "11,14,1z"
-            os: ubuntu-latest
-            container: ubuntu:18.04
-            install: clang-5.0
-          - toolset: clang
-            compiler: clang++-6.0
-            cxxstd: "11,14,17"
-            os: ubuntu-20.04
-            install: clang-6.0
-          - toolset: clang
-            compiler: clang++-7
-            cxxstd: "11,14,17"
-            os: ubuntu-20.04
-            install: clang-7
-          - toolset: clang
-            compiler: clang++-8
-            cxxstd: "11,14,17"
-            os: ubuntu-20.04
-            install: clang-8
-          - toolset: clang
-            compiler: clang++-9
-            cxxstd: "11,14,17"
-            os: ubuntu-20.04
-            install: clang-9
-          - toolset: clang
-            compiler: clang++-10
-            cxxstd: "11,14,17,2a"
-            os: ubuntu-20.04
-            install: clang-10
-          - toolset: clang
-            compiler: clang++-11
-            cxxstd: "11,14,17,2a"
-            os: ubuntu-20.04
-            install: clang-11
-          - toolset: clang
-            compiler: clang++-12
-            cxxstd: "11,14,17,2a"
-            os: ubuntu-20.04
-            install: clang-12
-          - toolset: clang
-            compiler: clang++-13
-            cxxstd: "11,14,17,20,2b"
-            os: ubuntu-22.04
-            install: clang-13
-          - toolset: clang
-            compiler: clang++-14
-            cxxstd: "11,14,17,20,2b"
-            os: ubuntu-22.04
-            install: clang-14
-          - toolset: clang
-            compiler: clang++-15
-            cxxstd: "11,14,17,20,2b"
-            os: ubuntu-22.04
-            install: clang-15
-          - toolset: clang
-            compiler: clang++-16
-            cxxstd: "11,14,17,20,2b"
-            os: ubuntu-latest
-            container: ubuntu:23.04
-            install: clang-16
-          - toolset: clang
-            cxxstd: "11,14,17,2a"
-            os: macos-11
-          - toolset: clang
-            cxxstd: "11,14,17,20,2b"
-            os: macos-12
-          - toolset: clang
-            cxxstd: "11,14,17,20,2b"
-            os: macos-13
+        include: ${{ fromJSON(needs.cpp-matrix.outputs.matrix) }}
 
-    runs-on: ${{matrix.os}}
-    container: ${{matrix.container}}
-
-    defaults:
-      run:
-        shell: bash
+    # use matrix entries
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runs-on }}
+    container: ${{ matrix.container }}
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup container environment
-        if: matrix.container
+      # GitHub Actions no longer support older containers.
+      # The workaround is to install our own Node.js for the actions.
+      - name: Patch Node
+        # The containers that need Node.js 20 will have volumes set up so that
+        # the Node.js 20 installation can go there.
+        if: ${{ matrix.container.volumes }}
         run: |
+          set -x
           apt-get update
-          apt-get -y install sudo python3 git g++
+          apt-get install -y curl xz-utils
+          curl -LO https://archives.boost.io/misc/node/node-v20.9.0-linux-x64-glibc-217.tar.xz
+          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
+          ldd /__e/node20/bin/node
 
-      - name: Install packages
-        if: matrix.install
-        run: sudo apt-get -y install ${{matrix.install}}
+      - name: Setup C++ Compiler
+        uses: alandefreitas/cpp-actions/setup-cpp@master
+        id: setup-cpp
+        with:
+          compiler: ${{ matrix.compiler }}
+          version: ${{ matrix.version }}
 
-      - name: Setup Boost
+      - name: Install Packages
+        if: matrix.install != ''
+        uses: alandefreitas/cpp-actions/package-install@master
+        id: package-install
+        with:
+          apt-get: ${{ matrix.install }}
+
+      - name: Clone Library
+        uses: actions/checkout@v4
+
+      - name: Clone Boost
+        uses: alandefreitas/cpp-actions/boost-clone@master
+        id: boost-clone
+        with:
+          branch: ${{ (github.ref_name == 'master' && github.ref_name) || 'develop' }}
+          boost-dir: ../boost-root
+          scan-modules-dir: .
+          scan-modules-ignore: ${{ matrix.boost-lib }}
+          modules-scan-paths: ${{ matrix.scan-dirs }}
+          cache: false
+
+      - name: Copy Library
+        shell: bash
         run: |
-          echo GITHUB_REPOSITORY: $GITHUB_REPOSITORY
-          LIBRARY=${GITHUB_REPOSITORY#*/}
-          echo LIBRARY: $LIBRARY
-          echo "LIBRARY=$LIBRARY" >> $GITHUB_ENV
-          echo GITHUB_BASE_REF: $GITHUB_BASE_REF
-          echo GITHUB_REF: $GITHUB_REF
-          REF=${GITHUB_BASE_REF:-$GITHUB_REF}
-          REF=${REF#refs/heads/}
-          echo REF: $REF
-          BOOST_BRANCH=develop && [ "$REF" == "master" ] && BOOST_BRANCH=master || true
-          echo BOOST_BRANCH: $BOOST_BRANCH
-          cd ..
-          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
-          cd boost-root
-          cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
-          git submodule update --init tools/boostdep
-          python3 tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY
-          ./bootstrap.sh
-          ./b2 -d0 headers
-
-      - name: Create user-config.jam
-        if: matrix.compiler
-        run: |
-          echo "using ${{matrix.toolset}} : : ${{matrix.compiler}} ;" > ~/user-config.jam
-
-      - name: Run tests
-        run: |
+          workspace_root=$(echo "$GITHUB_WORKSPACE" | sed 's/\\/\//g')
           cd ../boost-root
-          ./b2 -j3 libs/$LIBRARY/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} variant=debug,release
+          rm -rf "libs/${{ matrix.boost-lib }}"
+          mkdir "libs/${{ matrix.boost-lib }}"
+          cp -r "$workspace_root"/* "libs/${{ matrix.boost-lib }}"
 
-  windows:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - toolset: msvc-14.0
-            cxxstd: "14"
-            addrmd: 32,64
-            os: windows-2019
-          - toolset: msvc-14.2
-            cxxstd: "14,17,20,latest"
-            addrmd: 32
-            os: windows-2019
-          - toolset: msvc-14.2
-            cxxstd: "14,17,20,latest"
-            addrmd: 64
-            os: windows-2019
-          - toolset: msvc-14.3
-            cxxstd: "14,17,20,latest"
-            addrmd: 32
-            os: windows-2022
-          - toolset: msvc-14.3
-            cxxstd: "14,17,20,latest"
-            addrmd: 64
-            os: windows-2022
-          - toolset: clang-win
-            cxxstd: "14,17,latest"
-            addrmd: 32,64
-            os: windows-2022
-          - toolset: gcc
-            cxxstd: "11,14,17,2a"
-            addrmd: 64
-            os: windows-2019
-
-    runs-on: ${{matrix.os}}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Boost
-        shell: cmd
-        run: |
-          echo GITHUB_REPOSITORY: %GITHUB_REPOSITORY%
-          for /f %%i in ("%GITHUB_REPOSITORY%") do set LIBRARY=%%~nxi
-          echo LIBRARY: %LIBRARY%
-          echo LIBRARY=%LIBRARY%>>%GITHUB_ENV%
-          echo GITHUB_BASE_REF: %GITHUB_BASE_REF%
-          echo GITHUB_REF: %GITHUB_REF%
-          if "%GITHUB_BASE_REF%" == "" set GITHUB_BASE_REF=%GITHUB_REF%
-          set BOOST_BRANCH=develop
-          for /f %%i in ("%GITHUB_BASE_REF%") do if "%%~nxi" == "master" set BOOST_BRANCH=master
-          echo BOOST_BRANCH: %BOOST_BRANCH%
-          cd ..
-          git clone -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
-          cd boost-root
-          xcopy /s /e /q %GITHUB_WORKSPACE% libs\%LIBRARY%\
-          git submodule update --init tools/boostdep
-          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" %LIBRARY%
-          cmd /c bootstrap
-          b2 -d0 headers
-
-      - name: Run tests
-        shell: cmd
-        run: |
-          cd ../boost-root
-          b2 -j3 libs/%LIBRARY%/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} address-model=${{matrix.addrmd}} variant=debug,release embed-manifest-via=linker
+      - name: B2 Workflow
+        uses: alandefreitas/cpp-actions/b2-workflow@master
+        with:
+          source-dir: ${{ steps.boost-clone.outputs.boost-dir }}
+          modules: ${{ matrix.boost-lib }}
+          toolset: ${{ matrix.b2-toolset }}
+          build-variant: ${{ matrix.build-type }}
+          cxx: ${{ steps.setup-cpp.outputs.cxx || '' }}
+          cxxstd: ${{ matrix.cxxstd }}
+          address-model: ${{ matrix.address-model }}
+          asan: ${{ matrix.asan }}
+          ubsan: ${{ matrix.ubsan }}
+          tsan: ${{ matrix.tsan }}
+          shared: ${{ matrix.shared }}
+          abbreviate-paths: false
+          hash: true
+          debug-configuration: true
+          trace-commands: true


### PR DESCRIPTION
This rewrites the GHA CI to use https://github.com/alandefreitas/cpp-actions. It allows the CI setup to remain generic enough to flexibly handle changes to upstream GHA changes. Of course, assuming that cpp-actions adjusts accordingly. With that it also expands the testing coverage.