### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(boost_accumulators
     Boost::preprocessor
     Boost::range
     Boost::serialization
-    Boost::static_assert
     Boost::throw_exception
     Boost::tuple
     Boost::type_traits

--- a/build.jam
+++ b/build.jam
@@ -21,7 +21,6 @@ constant boost_dependencies :
     /boost/preprocessor//boost_preprocessor
     /boost/range//boost_range
     /boost/serialization//boost_serialization
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.